### PR TITLE
Add write perms to nightly build

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   nightly:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: checkout security_content_docs
         uses: actions/checkout@v3


### PR DESCRIPTION
Adding permissions to the nightly build to allow it to write back to the repo.