### PR TITLE
fix: playbooks moved to security_content, adjusting playbook explorer link accordingly

### DIFF
--- a/bin/jinja2_templates/doc_playbooks.j2
+++ b/bin/jinja2_templates/doc_playbooks.j2
@@ -39,7 +39,7 @@ tags:
 {{ playbook.how_to_implement}}
 
 {% if playbook.tags.vpe_type == "Modern" %}
-#### [Explore Playbook](https://splunk.github.io/soar-playbook-viewer/?playbook=https://raw.githubusercontent.com/phantomcyber/playbooks/latest/{{ playbook.playbook | replace(" ", "_")}}.json){: .btn .btn--info}
+#### [Explore Playbook](https://splunk.github.io/soar-playbook-viewer/?playbook=https://raw.githubusercontent.com/splunk/security_content/develop/playbooks/{{ playbook.playbook | replace(" ", "_")}}.json){: .btn .btn--info}
 
 [![explore](https://raw.githubusercontent.com/splunk/security_content/develop/playbooks/{{ playbook.playbook | replace(" ", "_")}}.png){:height="500px" width="500px"}](https://splunk.github.io/soar-playbook-viewer/?playbook=https://raw.githubusercontent.com/phantomcyber/playbooks/latest/{{ playbook.playbook | replace(" ", "_")}}.json)
 {% else %}


### PR DESCRIPTION
This PR adjusts the link of the "Explore Playbook" button to point to the new source of truth - the security content repository. The current state leads to 404's on a small number of playbook pages.